### PR TITLE
Add missing space in JavaScript code. #1555

### DIFF
--- a/src/site/resources/js/anchors.js
+++ b/src/site/resources/js/anchors.js
@@ -6,7 +6,7 @@ function main() {
     var url = window.location.href;
     var anchors = document.getElementsByTagName('h2');
     var mass = [];
-    for(var i = 0; i < anchors.length; i++) {
+    for (var i = 0; i < anchors.length; i++) {
         mass.push(anchors[i].childNodes[0].name);
     }
     var links = [];


### PR DESCRIPTION
Fixes some `JSLint` inspection violations.

Description:

> JSLint: Missing space between 'for' and '('. (at line 9)
