### PR TITLE
Issue #1555: Tune down inspection for overridden parameter names

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -1575,10 +1575,10 @@
     <inspection_tool class="ParameterNameDiffersFromOverriddenParameter" enabled="true" level="WARNING" enabled_by_default="true">
         <scope name="Production" level="WARNING" enabled="false">
             <option name="m_ignoreSingleCharacterNames" value="false" />
-            <option name="m_ignoreOverridesOfLibraryMethods" value="false" />
+            <option name="m_ignoreOverridesOfLibraryMethods" value="true" />
         </scope>
         <option name="m_ignoreSingleCharacterNames" value="false" />
-        <option name="m_ignoreOverridesOfLibraryMethods" value="false" />
+        <option name="m_ignoreOverridesOfLibraryMethods" value="true" />
     </inspection_tool>
     <inspection_tool class="ParameterNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
         <option name="m_regex" value="[a-z][A-Za-z\d]*" />

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
@@ -181,7 +181,7 @@ public class PackageNamesLoaderTest {
     private static URL getMockUrl(final URLConnection connection) throws IOException {
         final URLStreamHandler handler = new URLStreamHandler() {
             @Override
-            protected URLConnection openConnection(final URL u) {
+            protected URLConnection openConnection(final URL url) {
                 return connection;
             }
         };

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -260,8 +260,8 @@ public class XMLLoggerTest {
         private static final long serialVersionUID = 1L;
 
         @Override
-        public void printStackTrace(PrintWriter s) {
-            s.print("stackTrace");
+        public void printStackTrace(PrintWriter printWriter) {
+            printWriter.print("stackTrace");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/DetailASTTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/DetailASTTest.java
@@ -113,10 +113,10 @@ public class DetailASTTest {
     private static void checkDir(File dir) throws Exception {
         File[] files = dir.listFiles(new FileFilter() {
                 @Override
-                public boolean accept(File pathname) {
-                    return (pathname.getName().endsWith(".java")
-                            || pathname.isDirectory())
-                        && !pathname.getName().endsWith("InputGrammar.java");
+                public boolean accept(File file) {
+                    return (file.getName().endsWith(".java")
+                            || file.isDirectory())
+                        && !file.getName().endsWith("InputGrammar.java");
                 }
             });
         for (File file : files) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
@@ -106,7 +106,7 @@ public class LocalizedMessageTest {
     private static URL getMockUrl(final URLConnection connection) throws IOException {
         final URLStreamHandler handler = new URLStreamHandler() {
             @Override
-            protected URLConnection openConnection(final URL u) {
+            protected URLConnection openConnection(final URL url) {
                 return connection;
             }
         };


### PR DESCRIPTION
ParameterNameDiffersFromOverriddenParameter does not require parameters to match names anymore if method is from external library and parameter may be wrongly named there.
